### PR TITLE
Implement custom arena behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # `id-arena`
 
-[![](https://docs.rs/id-arena/badge.svg)](https://docs.rs/id-arena/)
 [![](https://img.shields.io/crates/v/id-arena.svg)](https://crates.io/crates/id-arena)
 [![](https://img.shields.io/crates/d/id-arena.svg)](https://crates.io/crates/id-arena)
 [![Travis CI Build Status](https://travis-ci.org/fitzgen/id-arena.svg?branch=master)](https://travis-ci.org/fitzgen/id-arena)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ pub enum AstNode {
     },
 }
 
-let mut ast_nodes = Arena::new();
+let mut ast_nodes = Arena::<AstNode>::new();
 
 // Create the AST for `a * (b + 3)`.
 let three = ast_nodes.alloc(AstNode::Const(3));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@
 //!     },
 //! }
 //!
-//! let mut ast_nodes = Arena::new();
+//! let mut ast_nodes = Arena::<AstNode>::new();
 //!
 //! // Create the AST for `a * (b + 3)`.
 //! let three = ast_nodes.alloc(AstNode::Const(3));
@@ -88,7 +88,6 @@
 #![forbid(unsafe_code)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
-
 // In no-std mode, use the alloc crate to get `Vec`.
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
@@ -118,6 +117,63 @@ mod imports {
 }
 
 use imports::*;
+
+/// A trait representing the implementation behavior of an arena and how
+/// identifiers are represented.
+///
+/// ## When should I implement `ArenaBehavior` myself?
+///
+/// Usually, you should just use `DefaultArenaBehavior`, which is simple and
+/// correct. However, there are some scenarios where you might want to implement
+/// `ArenaBehavior` yourself:
+///
+/// * **Space optimizations:** The default identifier is two words in size,
+/// which is larger than is usually necessary. For example, if you know that an
+/// arena *cannot* contain more than 256 items, you could make your own
+/// identifier type that stores the index as a `u8` and then you can save some
+/// space.
+///
+/// * **Trait Coherence:** If you need to implement an upstream crate's traits
+/// for identifiers, then defining your own identifier type allows you to work
+/// with trait coherence rules.
+///
+/// * **Share identifiers across arenas:** You can coordinate and share
+/// identifiers across different arenas to enable a "struct of arrays" style
+/// data representation.
+pub trait ArenaBehavior {
+    /// The identifier type.
+    type Id;
+
+    /// Construct a new object identifier from the given index and arena
+    /// identifier.
+    ///
+    /// ## Panics
+    ///
+    /// Implementations are allowed to panic if the given index is larger than
+    /// the underlying storage (e.g. the implementation uses a `u8` for storing
+    /// indices and the given index value is larger than 255).
+    fn new_id(index: usize, arena_id: usize) -> Self::Id;
+
+    /// Get the given identifier's index.
+    fn index(&Self::Id) -> usize;
+
+    /// Get the given identifier's arena id.
+    fn arena_id(&Self::Id) -> usize;
+
+    /// Construct a new arena identifier.
+    ///
+    /// This is used to disambiguate `Id`s across different arenas. To make
+    /// identifiers with the same index from different arenas compare false for
+    /// equality, return a unique `usize` on every invocation. This is the
+    /// default, provided implementation's behavior.
+    ///
+    /// To make identifiers with the same index from different arenas compare
+    /// true for equality, return the same `usize` on every invocation.
+    fn new_arena_id() -> usize {
+        static ARENA_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
+        ARENA_COUNTER.fetch_add(1, atomic::Ordering::SeqCst)
+    }
+}
 
 /// An identifier for an object allocated within an arena.
 pub struct Id<T> {
@@ -166,12 +222,41 @@ impl<T> Id<T> {
     }
 }
 
-static ARENA_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
+/// TODO
+#[derive(Debug)]
+pub struct DefaultArenaBehavior<T> {
+    _phantom: PhantomData<fn() -> T>,
+}
+
+impl<T> ArenaBehavior for DefaultArenaBehavior<T> {
+    type Id = Id<T>;
+
+    #[inline]
+    fn new_id(idx: usize, arena_id: usize) -> Self::Id {
+        Id {
+            idx,
+            arena_id,
+            _ty: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn index(id: &Self::Id) -> usize {
+        id.idx
+    }
+
+    #[inline]
+    fn arena_id(id: &Self::Id) -> usize {
+        id.arena_id
+    }
+}
 
 /// An arena of objects of type `T`.
 ///
 /// ```
-/// let mut arena = id_arena::Arena::new();
+/// use id_arena::{Arena, Id};
+///
+/// let mut arena = Arena::<&str>::new();
 ///
 /// let a = arena.alloc("Albert");
 /// assert_eq!(arena[a], "Albert");
@@ -180,49 +265,62 @@ static ARENA_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
 /// assert_eq!(arena[a], "Alice");
 /// ```
 #[derive(Debug)]
-pub struct Arena<T> {
+pub struct Arena<T, A = DefaultArenaBehavior<T>> {
     arena_id: usize,
     items: Vec<T>,
+    _phantom: PhantomData<fn() -> A>,
 }
 
-impl<T> Default for Arena<T> {
+impl<T, I, A> Default for Arena<T, A>
+where
+    A: ArenaBehavior<Id = I>,
+{
     #[inline]
-    fn default() -> Arena<T> {
+    fn default() -> Arena<T, A> {
         Arena {
-            arena_id: ARENA_COUNTER.fetch_add(1, atomic::Ordering::SeqCst),
+            arena_id: A::new_arena_id(),
             items: Vec::new(),
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<T> Arena<T> {
+impl<T, I, A> Arena<T, A>
+where
+    A: ArenaBehavior<Id = I>,
+{
     /// Construct a new, empty `Arena`.
     ///
     /// ```
-    /// let mut arena = id_arena::Arena::new();
+    /// use id_arena::{Arena, Id};
+    ///
+    /// let mut arena = Arena::<usize>::new();
     /// arena.alloc(42);
     /// ```
     #[inline]
-    pub fn new() -> Arena<T> {
+    pub fn new() -> Arena<T, A> {
         Default::default()
     }
 
     /// Allocate `item` within this arena and return its id.
     ///
     /// ```
-    /// let mut arena = id_arena::Arena::new();
-    /// arena.alloc(42);
+    /// use id_arena::{Arena, DefaultArenaBehavior};
+    ///
+    /// let mut arena = Arena::<usize>::new();
+    /// let _id = arena.alloc(42);
     /// ```
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the number of elements in the arena overflows a `usize` or
+    /// `Id`'s index storage representation.
     #[inline]
-    pub fn alloc(&mut self, item: T) -> Id<T> {
+    pub fn alloc(&mut self, item: T) -> A::Id {
         let arena_id = self.arena_id;
         let idx = self.items.len();
         self.items.push(item);
-        Id {
-            arena_id,
-            idx,
-            _ty: PhantomData,
-        }
+        A::new_id(idx, arena_id)
     }
 
     /// Get a shared reference to the object associated with the given `id` if
@@ -233,19 +331,21 @@ impl<T> Arena<T> {
     /// `None`.
     ///
     /// ```
-    /// let mut arena = id_arena::Arena::new();
+    /// use id_arena::{Arena, Id};
+    ///
+    /// let mut arena = Arena::<usize>::new();
     /// let id = arena.alloc(42);
     /// assert!(arena.get(id).is_some());
     ///
-    /// let other_arena = id_arena::Arena::new();
+    /// let other_arena = Arena::<usize>::new();
     /// assert!(other_arena.get(id).is_none());
     /// ```
     #[inline]
-    pub fn get(&self, id: Id<T>) -> Option<&T> {
-        if id.arena_id != self.arena_id {
+    pub fn get(&self, id: A::Id) -> Option<&T> {
+        if A::arena_id(&id) != self.arena_id {
             None
         } else {
-            self.items.get(id.idx)
+            self.items.get(A::index(&id))
         }
     }
 
@@ -257,26 +357,31 @@ impl<T> Arena<T> {
     /// `None`.
     ///
     /// ```
-    /// let mut arena = id_arena::Arena::new();
+    /// use id_arena::{Arena, Id};
+    ///
+    /// let mut arena = Arena::<usize>::new();
     /// let id = arena.alloc(42);
     /// assert!(arena.get_mut(id).is_some());
     ///
-    /// let mut other_arena = id_arena::Arena::new();
+    /// let mut other_arena = Arena::<usize>::new();
     /// assert!(other_arena.get_mut(id).is_none());
     /// ```
     #[inline]
-    pub fn get_mut(&mut self, id: Id<T>) -> Option<&mut T> {
-        if id.arena_id != self.arena_id {
+    pub fn get_mut(&mut self, id: A::Id) -> Option<&mut T> {
+        if A::arena_id(&id) != self.arena_id {
             None
         } else {
-            self.items.get_mut(id.idx)
+            self.items.get_mut(A::index(&id))
         }
     }
 
     /// Iterate over this arena's items and their ids.
     ///
     /// ```
-    /// let mut arena = id_arena::Arena::new();
+    /// use id_arena::{Arena, Id};
+    ///
+    /// let mut arena = Arena::<&str>::new();
+    ///
     /// arena.alloc("hello");
     /// arena.alloc("hi");
     /// arena.alloc("yo");
@@ -287,14 +392,17 @@ impl<T> Arena<T> {
     /// }
     /// ```
     #[inline]
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<T, A> {
         IntoIterator::into_iter(self)
     }
 
     /// Get the number of objects allocated in this arena.
     ///
     /// ```
-    /// let mut arena = id_arena::Arena::new();
+    /// use id_arena::{Arena, Id};
+    ///
+    /// let mut arena = Arena::<&str>::new();
+    ///
     /// arena.alloc("hello");
     /// arena.alloc("hi");
     ///
@@ -306,61 +414,68 @@ impl<T> Arena<T> {
     }
 }
 
-impl<T> ops::Index<Id<T>> for Arena<T> {
+impl<T, A> ops::Index<A::Id> for Arena<T, A>
+where
+    A: ArenaBehavior,
+{
     type Output = T;
 
     #[inline]
-    fn index(&self, id: Id<T>) -> &T {
-        assert_eq!(self.arena_id, id.arena_id);
-        &self.items[id.idx]
+    fn index(&self, id: A::Id) -> &T {
+        assert_eq!(self.arena_id, A::arena_id(&id));
+        &self.items[A::index(&id)]
     }
 }
 
-impl<T> ops::IndexMut<Id<T>> for Arena<T> {
+impl<T, A> ops::IndexMut<A::Id> for Arena<T, A>
+where
+    A: ArenaBehavior,
+{
     #[inline]
-    fn index_mut(&mut self, id: Id<T>) -> &mut T {
-        assert_eq!(self.arena_id, id.arena_id);
-        &mut self.items[id.idx]
+    fn index_mut(&mut self, id: A::Id) -> &mut T {
+        assert_eq!(self.arena_id, A::arena_id(&id));
+        &mut self.items[A::index(&id)]
     }
 }
 
-/// An iterator over `(Id<T>, &T)` pairs in an arena.
+/// An iterator over `(Id, &T)` pairs in an arena.
 ///
 /// See [the `Arena::iter()` method](./struct.Arena.html#method.iter) for details.
 #[derive(Debug)]
-pub struct Iter<'a, T: 'a> {
+pub struct Iter<'a, T: 'a, A: 'a> {
     arena_id: usize,
     iter: iter::Enumerate<slice::Iter<'a, T>>,
+    _phantom: PhantomData<fn() -> A>,
 }
 
-impl<'a, T: 'a> Iterator for Iter<'a, T> {
-    type Item = (Id<T>, &'a T);
+impl<'a, T: 'a, A: 'a> Iterator for Iter<'a, T, A>
+where
+    A: ArenaBehavior,
+{
+    type Item = (A::Id, &'a T);
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(idx, item)| {
             let arena_id = self.arena_id;
-            (
-                Id {
-                    arena_id,
-                    idx,
-                    _ty: PhantomData,
-                },
-                item,
-            )
+            (A::new_id(idx, arena_id), item)
         })
     }
 }
 
-impl<'a, T> IntoIterator for &'a Arena<T> {
-    type Item = (Id<T>, &'a T);
-    type IntoIter = Iter<'a, T>;
+impl<'a, T, A> IntoIterator for &'a Arena<T, A>
+where
+    A: ArenaBehavior,
+{
+    type Item = (A::Id, &'a T);
+    type IntoIter = Iter<'a, T, A>;
 
     #[inline]
-    fn into_iter(self) -> Iter<'a, T> {
+    fn into_iter(self) -> Iter<'a, T, A> {
         Iter {
             arena_id: self.arena_id,
             iter: self.items.iter().enumerate(),
+            _phantom: PhantomData,
         }
     }
 }
@@ -371,8 +486,7 @@ mod tests {
 
     #[test]
     fn ids_are_send_sync() {
-        fn assert_send_sync<T: Send + Sync>() {
-        }
+        fn assert_send_sync<T: Send + Sync>() {}
         struct Foo;
         assert_send_sync::<Id<Foo>>();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ impl<T> Id<T> {
     }
 }
 
-/// TODO
+/// The default `ArenaBehavior` implementation.
 #[derive(Debug)]
 pub struct DefaultArenaBehavior<T> {
     _phantom: PhantomData<fn() -> T>,
@@ -254,7 +254,7 @@ impl<T> ArenaBehavior for DefaultArenaBehavior<T> {
 /// An arena of objects of type `T`.
 ///
 /// ```
-/// use id_arena::{Arena, Id};
+/// use id_arena::Arena;
 ///
 /// let mut arena = Arena::<&str>::new();
 ///
@@ -292,7 +292,7 @@ where
     /// Construct a new, empty `Arena`.
     ///
     /// ```
-    /// use id_arena::{Arena, Id};
+    /// use id_arena::Arena;
     ///
     /// let mut arena = Arena::<usize>::new();
     /// arena.alloc(42);
@@ -331,7 +331,7 @@ where
     /// `None`.
     ///
     /// ```
-    /// use id_arena::{Arena, Id};
+    /// use id_arena::Arena;
     ///
     /// let mut arena = Arena::<usize>::new();
     /// let id = arena.alloc(42);
@@ -357,7 +357,7 @@ where
     /// `None`.
     ///
     /// ```
-    /// use id_arena::{Arena, Id};
+    /// use id_arena::Arena;
     ///
     /// let mut arena = Arena::<usize>::new();
     /// let id = arena.alloc(42);
@@ -378,7 +378,7 @@ where
     /// Iterate over this arena's items and their ids.
     ///
     /// ```
-    /// use id_arena::{Arena, Id};
+    /// use id_arena::Arena;
     ///
     /// let mut arena = Arena::<&str>::new();
     ///
@@ -399,7 +399,7 @@ where
     /// Get the number of objects allocated in this arena.
     ///
     /// ```
-    /// use id_arena::{Arena, Id};
+    /// use id_arena::Arena;
     ///
     /// let mut arena = Arena::<&str>::new();
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-//! [![](https://docs.rs/id-arena/badge.svg)](https://docs.rs/id-arena/)
 //! [![](https://img.shields.io/crates/v/id-arena.svg)](https://crates.io/crates/id-arena)
 //! [![](https://img.shields.io/crates/d/id-arena.svg)](https://crates.io/crates/id-arena)
 //! [![Travis CI Build Status](https://travis-ci.org/fitzgen/id-arena.svg?branch=master)](https://travis-ci.org/fitzgen/id-arena)
@@ -142,7 +141,7 @@ use imports::*;
 /// data representation.
 pub trait ArenaBehavior {
     /// The identifier type.
-    type Id;
+    type Id: Copy;
 
     /// Construct a new object identifier from the given index and arena
     /// identifier.
@@ -155,10 +154,10 @@ pub trait ArenaBehavior {
     fn new_id(index: usize, arena_id: usize) -> Self::Id;
 
     /// Get the given identifier's index.
-    fn index(&Self::Id) -> usize;
+    fn index(Self::Id) -> usize;
 
     /// Get the given identifier's arena id.
-    fn arena_id(&Self::Id) -> usize;
+    fn arena_id(Self::Id) -> usize;
 
     /// Construct a new arena identifier.
     ///
@@ -241,12 +240,12 @@ impl<T> ArenaBehavior for DefaultArenaBehavior<T> {
     }
 
     #[inline]
-    fn index(id: &Self::Id) -> usize {
+    fn index(id: Self::Id) -> usize {
         id.idx
     }
 
     #[inline]
-    fn arena_id(id: &Self::Id) -> usize {
+    fn arena_id(id: Self::Id) -> usize {
         id.arena_id
     }
 }
@@ -271,9 +270,9 @@ pub struct Arena<T, A = DefaultArenaBehavior<T>> {
     _phantom: PhantomData<fn() -> A>,
 }
 
-impl<T, I, A> Default for Arena<T, A>
+impl<T, A> Default for Arena<T, A>
 where
-    A: ArenaBehavior<Id = I>,
+    A: ArenaBehavior,
 {
     #[inline]
     fn default() -> Arena<T, A> {
@@ -285,9 +284,9 @@ where
     }
 }
 
-impl<T, I, A> Arena<T, A>
+impl<T, A> Arena<T, A>
 where
-    A: ArenaBehavior<Id = I>,
+    A: ArenaBehavior,
 {
     /// Construct a new, empty `Arena`.
     ///
@@ -342,10 +341,10 @@ where
     /// ```
     #[inline]
     pub fn get(&self, id: A::Id) -> Option<&T> {
-        if A::arena_id(&id) != self.arena_id {
+        if A::arena_id(id) != self.arena_id {
             None
         } else {
-            self.items.get(A::index(&id))
+            self.items.get(A::index(id))
         }
     }
 
@@ -368,10 +367,10 @@ where
     /// ```
     #[inline]
     pub fn get_mut(&mut self, id: A::Id) -> Option<&mut T> {
-        if A::arena_id(&id) != self.arena_id {
+        if A::arena_id(id) != self.arena_id {
             None
         } else {
-            self.items.get_mut(A::index(&id))
+            self.items.get_mut(A::index(id))
         }
     }
 
@@ -422,8 +421,8 @@ where
 
     #[inline]
     fn index(&self, id: A::Id) -> &T {
-        assert_eq!(self.arena_id, A::arena_id(&id));
-        &self.items[A::index(&id)]
+        assert_eq!(self.arena_id, A::arena_id(id));
+        &self.items[A::index(id)]
     }
 }
 
@@ -433,8 +432,8 @@ where
 {
     #[inline]
     fn index_mut(&mut self, id: A::Id) -> &mut T {
-        assert_eq!(self.arena_id, A::arena_id(&id));
-        &mut self.items[A::index(&id)]
+        assert_eq!(self.arena_id, A::arena_id(id));
+        &mut self.items[A::index(id)]
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ impl<T> ArenaBehavior for DefaultArenaBehavior<T> {
 /// arena[a] = "Alice";
 /// assert_eq!(arena[a], "Alice");
 /// ```
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Arena<T, A = DefaultArenaBehavior<T>> {
     arena_id: usize,
     items: Vec<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ impl<T> Id<T> {
 }
 
 /// The default `ArenaBehavior` implementation.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DefaultArenaBehavior<T> {
     _phantom: PhantomData<fn() -> T>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ pub trait ArenaBehavior {
     /// Implementations are allowed to panic if the given index is larger than
     /// the underlying storage (e.g. the implementation uses a `u8` for storing
     /// indices and the given index value is larger than 255).
-    fn new_id(index: usize, arena_id: usize) -> Self::Id;
+    fn new_id(arena_id: usize, index: usize) -> Self::Id;
 
     /// Get the given identifier's index.
     fn index(Self::Id) -> usize;
@@ -231,7 +231,7 @@ impl<T> ArenaBehavior for DefaultArenaBehavior<T> {
     type Id = Id<T>;
 
     #[inline]
-    fn new_id(idx: usize, arena_id: usize) -> Self::Id {
+    fn new_id(arena_id: usize, idx: usize) -> Self::Id {
         Id {
             idx,
             arena_id,
@@ -319,7 +319,7 @@ where
         let arena_id = self.arena_id;
         let idx = self.items.len();
         self.items.push(item);
-        A::new_id(idx, arena_id)
+        A::new_id(arena_id, idx)
     }
 
     /// Get a shared reference to the object associated with the given `id` if
@@ -457,7 +457,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(idx, item)| {
             let arena_id = self.arena_id;
-            (A::new_id(idx, arena_id), item)
+            (A::new_id(arena_id, idx), item)
         })
     }
 }


### PR DESCRIPTION
WIP fix for #1

@matklad what do you think of this? Would this enable the use cases you're thinking of? By customizing `ArenaBehavior::new_arena_id`, and adding some missing impls, we could also make arenas compare for equality.