### PR TITLE
Update to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT/Apache-2.0"
 name = "id-arena"
 readme = "README.md"
 repository = "https://github.com/fitzgen/id-arena"
+edition = "2021"
 version = "2.2.1"
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ use core::iter;
 use core::marker::PhantomData;
 use core::ops;
 use core::slice;
-use core::sync::atomic::{self, AtomicUsize, ATOMIC_USIZE_INIT};
+use core::sync::atomic::{self, AtomicUsize};
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
@@ -126,7 +126,7 @@ use std::vec::{self, Vec};
 #[cfg(feature = "rayon")]
 mod rayon;
 #[cfg(feature = "rayon")]
-pub use rayon::*;
+pub use crate::rayon::*;
 
 /// A trait representing the implementation behavior of an arena and how
 /// identifiers are represented.
@@ -165,10 +165,10 @@ pub trait ArenaBehavior {
     fn new_id(arena_id: u32, index: usize) -> Self::Id;
 
     /// Get the given identifier's index.
-    fn index(Self::Id) -> usize;
+    fn index(id: Self::Id) -> usize;
 
     /// Get the given identifier's arena id.
-    fn arena_id(Self::Id) -> u32;
+    fn arena_id(id: Self::Id) -> u32;
 
     /// Construct a new arena identifier.
     ///
@@ -180,7 +180,7 @@ pub trait ArenaBehavior {
     /// To make identifiers with the same index from different arenas compare
     /// true for equality, return the same `u32` on every invocation.
     fn new_arena_id() -> u32 {
-        static ARENA_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
+        static ARENA_COUNTER: AtomicUsize = AtomicUsize::new(0);
         ARENA_COUNTER.fetch_add(1, atomic::Ordering::SeqCst) as u32
     }
 }


### PR DESCRIPTION
Deprecated `ATOMIC_USIZE_INIT` in favor of `AtomicUsize::new(0)` after [Rust 1.34 release](https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html).

Fix crate path issue for `rayon`.

Starting from edition 2018, "anonymous trait function parameters" is [deprecated](https://doc.rust-lang.org/edition-guide/rust-2018/trait-fn-parameters.html).