### PR TITLE
feat: add support for serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ features = ['rayon']
 
 [dependencies]
 rayon = { version = "1.0.3", optional = true }
+serde = { version = "^1.0", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This PR adds serde support to `Arena` and `Id` structs. This helps the implementation of https://github.com/bytecodealliance/wasm-tools/pull/1177 